### PR TITLE
chore: use correct version of eslint-config-unumux

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -45,7 +45,7 @@
     "url": ""
   },
   "eslintConfig": {
-      "extends": "@unumux/eslint-config-unumux"
+      "extends": "@unumux/eslint-config-unumux/node"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
eslint-config-unumux was using the browser defaults. Change to use the node presets
